### PR TITLE
Back button removed and quests hidden if none

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,8 +1,5 @@
 <div class="container col-lg-6 col-xl-6 col-sm-12 col-md-8 col-12">
   <div class="d-flex align-items-center">
-    <div class="btn nav">
-      <i class="fas fa-arrow-left"></i>  <%= link_to "Back", :back, class: "light-font" %>
-    </div>
     <h2 class="ml-3 mt-2">Edit Your Account Settings</h2>
   </div>
   <hr>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,7 +26,7 @@
               <% end %>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                 <%= link_to "Profile", user_path(current_user), class: "dropdown-item" %>
-                <%= link_to "Settings", "#", class: "dropdown-item" %>
+                <%= link_to "Settings", edit_user_registration_path, class: "dropdown-item" %>
                 <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
               </div>
             </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,22 +38,24 @@
     <% end %>
   </div>
 </div>
-<div class="user-groups">
-  <h3>Your Team Adventures</h3>
-  <table class="user-groups-table">
-    <tr>
-      <td>Team</td>
-      <td>Language</td>
-      <td>Civilisation</td>
-      <td>Points Contribution</td>
-    </tr>
-    <% current_user.group_memberships.order(points: :desc).each do |membership| %>
+<% if !current_user.groups.empty?%>
+  <div class="user-groups">
+    <h3>Your Team Adventures</h3>
+    <table class="user-groups-table">
       <tr>
-        <td><%= membership.group.name %></td>
-        <td><%= membership.language.name %></td>
-        <td>Town</td>
-        <td><%= membership.points %></td>
+        <td>Team</td>
+        <td>Language</td>
+        <td>Civilisation</td>
+        <td>Points Contribution</td>
       </tr>
-    <% end %>
-  </table>
-</div>
+      <% current_user.group_memberships.order(points: :desc).each do |membership| %>
+        <tr>
+          <td><%= membership.group.name %></td>
+          <td><%= membership.language.name %></td>
+          <td>Town</td>
+          <td><%= membership.points %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% end %>


### PR DESCRIPTION
Removed the back button from the registration edit page. The settings dropdown on the navbar takes you to the edit page and if you have no groups the table is not shown